### PR TITLE
Drivers license

### DIFF
--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -22,7 +22,7 @@ class Facility
   end
 
   def register_vehicle(vehicle)
-    if @services.include?("Vehicle Registration")
+    if @services.include?('Vehicle Registration')
       vehicle.registration_date = Date.today.year
       if vehicle.antique?
         @collected_fees += 25
@@ -37,6 +37,19 @@ class Facility
       @registered_vehicles << vehicle
     else
       nil
+    end
+  end
+
+  def administer_written_test(registrant)
+    if @services.include?('Written Test')
+      true
+      if registrant.permit? == true && registrant.age >= 16
+        registrant.license_data[:written] = true
+      else
+        registrant.license_data[:written] = false
+      end
+    else
+      false
     end
   end
 end

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -68,19 +68,28 @@ RSpec.describe Facility do
 
   describe '#administer_written_test' do
     it 'can give a written test' do
-      require 'pry'; binding.pry
       expect(@registrant_1.license_data).to eq({:written=>false, :license=>false, :renewed=>false})
       expect(@registrant_1.permit?).to eq(true)
       expect(@facility_1.administer_written_test(@registrant_1)).to eq(false)
       expect(@registrant_1.license_data).to eq({:written=>false, :license=>false, :renewed=>false})
       @facility_1.add_service('Written Test')
-      expect(@facility_1.add_service('Written Test')).to eq(["Written Test"])
+      expect(@facility_1.services).to eq(["Written Test"])
       expect(@facility_1.administer_written_test(@registrant_1)).to eq(true)
       expect(@registrant_1.license_data).to eq({:written=>true, :license=>false, :renewed=>false})
 
+      expect(@registrant_2.age).to eq(16)
+      expect(@registrant_2.permit?).to eq(false)
+      expect(@facility_1.administer_written_test(@registrant_2)).to eq(false)
+      @registrant_2.earn_permit
+      expect(@facility_1.administer_written_test(@registrant_2)).to eq(true)
+      expect(@registrant_2.license_data).to eq({:written=>true, :license=>false, :renewed=>false})
+
+      expect(@registrant_3.age).to eq(15)
+      expect(@registrant_3.permit?).to eq(false)
+      expect(@facility_1.administer_written_test(@registrant_3)).to eq(false)
+      @registrant_3.earn_permit
+      expect(@facility_1.administer_written_test(@registrant_3)).to eq(false)
+      expect(@registrant_3.license_data).to eq({:written=>false, :license=>false, :renewed=>false})
     end
   end
-
-  
-  
 end

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe Facility do
     @cruz = Vehicle.new({vin: '123456789abcdefgh', year: 2012, make: 'Chevrolet', model: 'Cruz', engine: :ice} )
     @bolt = Vehicle.new({vin: '987654321abcdefgh', year: 2019, make: 'Chevrolet', model: 'Bolt', engine: :ev} )
     @camaro = Vehicle.new({vin: '1a2b3c4d5e6f', year: 1969, make: 'Chevrolet', model: 'Camaro', engine: :ice} )
+
+    @registrant_1 = Registrant.new('Bruce', 18, true )
+    @registrant_2 = Registrant.new('Penny', 16 )
+    @registrant_3 = Registrant.new('Tucker', 15 )
   end
   describe '#initialize' do
     it 'can initialize' do
@@ -62,6 +66,20 @@ RSpec.describe Facility do
     end
   end
 
+  describe '#adminster_written_test' do
+    it 'can give a written test' do
+      require 'pry'; binding.pry
+      expect(@registrant_1.license_data).to eq({:written=>false, :license=>false, :renewed=>false})
+      expect(@registrant_1.permit?).to eq(true)
+      expect(@facility_1.administer_written_test(@registrant_1)).to eq(false)
+      expect(@registrant_1.license_data).to eq({:written=>false, :license=>false, :renewed=>false})
+      @facility_1.add_service('Written Test')
+      expect(@facility_1.add_service('Written Test')).to eq(["Written Test"])
+      expect(@facility_1.administer_written_test(@registrant_1)).to eq(true)
+      expect(@registrant_1.license_data).to eq({:written=>true, :license=>false, :renewed=>false})
+
+    end
+  end
 
   
   

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Facility do
     end
   end
 
-  describe '#adminster_written_test' do
+  describe '#administer_written_test' do
     it 'can give a written test' do
       require 'pry'; binding.pry
       expect(@registrant_1.license_data).to eq({:written=>false, :license=>false, :renewed=>false})


### PR DESCRIPTION
This adds a new method for administering written tests. It checks to see if the registrant has a permit and is at least 16 years old before administering a written test.